### PR TITLE
[Maintenance] Add body to post request

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    audience-api (1.1.0)
+    audience-api (1.1.1)
       faraday (~> 1.0)
       faraday_middleware (~> 1.0)
       hashie

--- a/lib/audience/api/client/gdpr.rb
+++ b/lib/audience/api/client/gdpr.rb
@@ -11,7 +11,10 @@ module Audience
         def gdpr_removal(email)
           raise "No email given!" if email.blank?
 
-          response = post "#{ENDPOINT}/removal/?email=#{email}"
+          response = post(
+            "#{ENDPOINT}/removal/",
+            {email: email}.to_json
+          )
           response.body
         end
       end

--- a/lib/audience/api/request.rb
+++ b/lib/audience/api/request.rb
@@ -12,11 +12,12 @@ module Audience
       end
 
       # Perform an HTTP POST request
-      def post(path, options={})
+      def post(path, body = nil, options={})
         options["format"] = "json"
         connection.post do |request|
           request.url URI.encode(path)
           request.params.merge! options
+          request.body = body if body
         end
       end
     end

--- a/lib/audience/api/version.rb
+++ b/lib/audience/api/version.rb
@@ -1,5 +1,5 @@
 module Audience
   module Api
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
### WHY
Edge case from https://github.com/mynewsdesk/mynewsdesk/pull/7183.
Passing an email as url param will result in encoding issues ("test+1@example.com" will be encoded as "test 1%40example.com", and fail the lookups down the line).

### WHAT
Since the endpoints on `mnd-audience` are already accepting `json`, I added support for a body in the `post` call, and passed the email in the body instead. 
This makes sense in general and also avoids having to do changes in `prime` and `mnd-audience`.